### PR TITLE
Missing class-specific features (class_features_data)

### DIFF
--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -866,7 +866,7 @@ class Character:
             return None
 
         # Load level appropriate class features
-        data = SRD_class_levels[class_name][class_level - 1]["class_specific"]
+        data = SRD_class_levels[class_name.lower()][class_level - 1]["class_specific"]
 
         # Create class feature counters
         if self.class_index == "Barbarian":

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -1027,4 +1027,4 @@ class Character:
             if reset_day_counters:
                 data["days_since_last_arcane_recovery"] = 999  # 1 day cooldown
 
-        return features
+        return data

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -862,32 +862,32 @@ class Character:
         """
         Creates a dict for class features. Assumes a fully rested character!
         """
-        if class_level is None:
+        if class_level is None or class_name is None:
             return None
 
         # Load level appropriate class features
         data = SRD_class_levels[class_name.lower()][class_level - 1]["class_specific"]
 
         # Create class feature counters
-        if self.class_index == "Barbarian":
+        if class_index == "Barbarian":
             data["max_rage_count"] = data["rage_count"]
             data.pop("rage_count")
 
-        elif self.class_index == "Bard":
+        elif class_index == "Bard":
             data["max_inspiration_count"] = max(
                 1, self.get_ability_modifier(self.charisma)
             )
 
-        elif self.class_index == "Cleric":
+        elif class_index == "Cleric":
             data["max_channel_divinity_charges"] = data["channel_divinity_charges"]
             data.pop("channel_divinity_charges")
 
             data["max_divine_intervention_charges"] = 1 if class_level >= 10 else 0
 
-        elif self.class_index == "Druid":
+        elif class_index == "Druid":
             data["max_wild_shape_charges"] = 1 if class_level >= 2 else 0
 
-        elif self.class_index == "Fighter":
+        elif class_index == "Fighter":
             data["max_action_surges"] = data["action_surges"]
             data.pop("action_surges")
 
@@ -897,13 +897,13 @@ class Character:
             data["max_second_wind"] = 1
             data["available_second_wind"] = 1
 
-        elif self.class_index == "Monk":
+        elif class_index == "Monk":
             data["max_ki_points"] = data["ki_points"]
             data.pop("ki_points")
 
             data["max_wholeness_of_body"] = 1 if class_level >= 6 else 0
 
-        elif self.class_index == "Paladin":
+        elif class_index == "Paladin":
             data["max_divine_sense"] = 1 + self.get_ability_modifier(self.charisma)
             data["max_lay_on_hands_points"] = 5 * class_level
             data["max_channel_divinity"] = 1
@@ -911,17 +911,17 @@ class Character:
                 1, self.get_ability_modifier(self.charisma)
             )
 
-        elif self.class_index == "Ranger":
+        elif class_index == "Ranger":
             pass  # No interaction between class features and rest mechanic
 
-        elif self.class_index == "Rogue":
+        elif class_index == "Rogue":
             data["max_stroke_of_luck"] = 1 if class_level >= 20 else 0
 
-        elif self.class_index == "Sorcerer":
+        elif class_index == "Sorcerer":
             data["max_sorcery_points"] = data["sorcery_points"]
             data.pop("sorcery_points")
 
-        elif self.class_index == "Warlock":
+        elif class_index == "Warlock":
             data["max_mire_the_mind"] = 1 if class_level >= 5 else 0
             data["max_sign_of_ill_omen"] = 1 if class_level >= 5 else 0
             data["max_dark_one's_own_luck"] = 1 if class_level >= 6 else 0
@@ -935,11 +935,8 @@ class Character:
             data["max_chains_of_carceri"] = 1 if class_level >= 20 else 0
             data["max_eldritch_master"] = 1 if class_level >= 20 else 0
 
-        elif self.class_index == "Wizard":
+        elif class_index == "Wizard":
             data["max_arcane_recovery"] = 1
-
-        else:
-            return None
 
         # Assign counters (initialized for a fully rested state)
         data = self.reset_class_features_data_counters(

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -80,6 +80,7 @@ class Character:
         ability_score_bonus: int = 0,
         class_features: Optional[dict] = None,
         class_features_enabled: Optional[list] = None,
+        class_features_data: Optional[list] = None,
         spellcasting_stat: Optional[str] = None,
         player_options: Optional[dict] = None,
         armor_class: Optional[int] = None,
@@ -132,6 +133,14 @@ class Character:
             ), "Alignments must be 2 letters (i.e LE, LG, TN, NG, CN)"
             self.alignment = self.alignment.upper()
 
+        # Ability Scores
+        self.strength = self.set_initial_ability_score(strength)
+        self._dexterity = self.set_initial_ability_score(dexterity)
+        self.constitution = self.set_initial_ability_score(constitution)
+        self.wisdom = self.set_initial_ability_score(wisdom)
+        self.intelligence = self.set_initial_ability_score(intelligence)
+        self.charisma = self.set_initial_ability_score(charisma)
+
         # DND Class
         self.class_name = class_name
         self.class_index = class_index
@@ -145,16 +154,8 @@ class Character:
             class_features_enabled if class_features_enabled is not None else []
         )
         self.class_features_data = self.get_class_features_data(
-            class_name=self.class_name, class_level=level
+            class_name=self.class_name, class_level=1 if level is None else int(level)
         )
-
-        # Ability Scores
-        self.strength = self.set_initial_ability_score(strength)
-        self._dexterity = self.set_initial_ability_score(dexterity)
-        self.constitution = self.set_initial_ability_score(constitution)
-        self.wisdom = self.set_initial_ability_score(wisdom)
-        self.intelligence = self.set_initial_ability_score(intelligence)
-        self.charisma = self.set_initial_ability_score(charisma)
 
         # Hit Dice and Hit Points: self.hd == 8 is a d8, 10 is a d10, etc
         self.hd = 8 if hd is None else hd
@@ -872,7 +873,9 @@ class Character:
             return None
 
         # Load level appropriate class features
-        data = SRD_class_levels[class_name.lower()][class_level - 1]["class_specific"]
+        data = SRD_class_levels[class_name.lower()][class_level - 1][
+            "class_specific"
+        ].copy()
 
         # Create class feature counters
         if class_name == "Barbarian":

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -147,16 +147,14 @@ class Character:
         self._class_levels = (
             [] if class_index not in SRD_class_levels else SRD_class_levels[class_index]
         )
-        self._level = 1 # may be increased later in this method
+        self._level = 1  # may be increased later in this method
         self.prof_bonus = prof_bonus
         self.ability_score_bonus = ability_score_bonus
         self.class_features = class_features if class_features is not None else {}
         self.class_features_enabled = (
             class_features_enabled if class_features_enabled is not None else []
         )
-        self._class_features_data = get_class_features_data(
-            character=self
-        )
+        self._class_features_data = get_class_features_data(character=self)
 
         # Hit Dice and Hit Points: self.hd == 8 is a d8, 10 is a d10, etc
         self.hd = 8 if hd is None else hd

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -869,25 +869,25 @@ class Character:
         data = SRD_class_levels[class_name.lower()][class_level - 1]["class_specific"]
 
         # Create class feature counters
-        if class_index == "Barbarian":
+        if class_name == "Barbarian":
             data["max_rage_count"] = data["rage_count"]
             data.pop("rage_count")
 
-        elif class_index == "Bard":
+        elif class_name == "Bard":
             data["max_inspiration_count"] = max(
                 1, self.get_ability_modifier(self.charisma)
             )
 
-        elif class_index == "Cleric":
+        elif class_name == "Cleric":
             data["max_channel_divinity_charges"] = data["channel_divinity_charges"]
             data.pop("channel_divinity_charges")
 
             data["max_divine_intervention_charges"] = 1 if class_level >= 10 else 0
 
-        elif class_index == "Druid":
+        elif class_name == "Druid":
             data["max_wild_shape_charges"] = 1 if class_level >= 2 else 0
 
-        elif class_index == "Fighter":
+        elif class_name == "Fighter":
             data["max_action_surges"] = data["action_surges"]
             data.pop("action_surges")
 
@@ -897,13 +897,13 @@ class Character:
             data["max_second_wind"] = 1
             data["available_second_wind"] = 1
 
-        elif class_index == "Monk":
+        elif class_name == "Monk":
             data["max_ki_points"] = data["ki_points"]
             data.pop("ki_points")
 
             data["max_wholeness_of_body"] = 1 if class_level >= 6 else 0
 
-        elif class_index == "Paladin":
+        elif class_name == "Paladin":
             data["max_divine_sense"] = 1 + self.get_ability_modifier(self.charisma)
             data["max_lay_on_hands_points"] = 5 * class_level
             data["max_channel_divinity"] = 1
@@ -911,17 +911,17 @@ class Character:
                 1, self.get_ability_modifier(self.charisma)
             )
 
-        elif class_index == "Ranger":
+        elif class_name == "Ranger":
             pass  # No interaction between class features and rest mechanic
 
-        elif class_index == "Rogue":
+        elif class_name == "Rogue":
             data["max_stroke_of_luck"] = 1 if class_level >= 20 else 0
 
-        elif class_index == "Sorcerer":
+        elif class_name == "Sorcerer":
             data["max_sorcery_points"] = data["sorcery_points"]
             data.pop("sorcery_points")
 
-        elif class_index == "Warlock":
+        elif class_name == "Warlock":
             data["max_mire_the_mind"] = 1 if class_level >= 5 else 0
             data["max_sign_of_ill_omen"] = 1 if class_level >= 5 else 0
             data["max_dark_one's_own_luck"] = 1 if class_level >= 6 else 0
@@ -935,7 +935,7 @@ class Character:
             data["max_chains_of_carceri"] = 1 if class_level >= 20 else 0
             data["max_eldritch_master"] = 1 if class_level >= 20 else 0
 
-        elif class_index == "Wizard":
+        elif class_name == "Wizard":
             data["max_arcane_recovery"] = 1
 
         # Assign counters (initialized for a fully rested state)
@@ -955,15 +955,15 @@ class Character:
         if not (short_rest and long_rest):
             raise InvalidParameterError("At least one rest type should be True!")
 
-        if self.class_index == "Barbarian":
+        if self.class_name == "Barbarian":
             if long_rest:
                 data["available_rage_count"] = data["max_rage_count"]
 
-        elif self.class_index == "Bard":
+        elif self.class_name == "Bard":
             if long_rest or self.level >= 5:
                 data["available_inspiration_count"] = data["max_inspiration_count"]
 
-        elif self.class_index == "Cleric":
+        elif self.class_name == "Cleric":
             if long_rest:
                 data["available_divine_intervention_charges"] = data[
                     "max_divine_intervention_charges"
@@ -974,37 +974,37 @@ class Character:
             if reset_day_counters:
                 data["days_since_last_divine_intervention"] = 999  # 7 day cooldown
 
-        elif self.class_index == "Druid":
+        elif self.class_name == "Druid":
             data["available_wild_shape_charges"] = data["max_wild_shape_charges"]
 
-        elif self.class_index == "Fighter":
+        elif self.class_name == "Fighter":
             data["available_action_surges"] = data["max_action_surges"]
             data["available_indomitable_uses"] = data["max_indomitable_uses"]
             data["available_second_wind"] = 1
 
-        elif self.class_index == "Monk":
+        elif self.class_name == "Monk":
             if long_rest:
                 data["available_wholeness_of_body"] = data["max_wholeness_of_body"]
             data["available_ki_points"] = data["max_ki_points"]
 
-        elif self.class_index == "Paladin":
+        elif self.class_name == "Paladin":
             if long_rest:
                 data["available_divine_sense"] = data["max_divine_sense"]
                 data["available_lay_on_hands_points"] = data["max_lay_on_hands_points"]
                 data["available_cleansing_touch"] = data["max_cleansing_touch"]
             data["available_channel_divinity"] = 1
 
-        elif self.class_index == "Ranger":
+        elif self.class_name == "Ranger":
             pass  # No interaction between class features and rest mechanic
 
-        elif self.class_index == "Rogue":
+        elif self.class_name == "Rogue":
             data["available_stroke_of_luck"] = data["max_stroke_of_luck"]
 
-        elif self.class_index == "Sorcerer":
+        elif self.class_name == "Sorcerer":
             if long_rest:
                 data["available_sorcery_points"] = data["max_sorcery_points"]
 
-        elif self.class_index == "Warlock":
+        elif self.class_name == "Warlock":
             if long_rest:
                 data["available_mire_the_mind"] = data["max_mire_the_mind"]
                 data["available_sign_of_ill_omen"] = data["max_sign_of_ill_omen"]
@@ -1019,7 +1019,7 @@ class Character:
                 data["available_chains_of_carceri"] = data["max_chains_of_carceri"]
                 data["available_eldritch_master"] = data["max_eldritch_master"]
 
-        elif self.class_index == "Wizard":
+        elif self.class_name == "Wizard":
             data["available_arcane_recovery"] = data["max_arcane_recovery"]
             if reset_day_counters:
                 data["days_since_last_arcane_recovery"] = 999  # 1 day cooldown

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -660,12 +660,15 @@ class Character:
         new_cfd = self.get_class_features_data(
             class_name=self.class_name, class_level=self.level
         )
-        self.class_features_data = {
-            k: v
-            if "available" not in k and "days" not in k
-            else self.class_features_data[k]
-            for k, v in new_cfd.items()
-        }
+        if new_cfd is None:
+            self.class_features_data = None
+        else:
+            self.class_features_data = {
+                k: v
+                if "available" not in k and "days" not in k
+                else self.class_features_data[k]
+                for k, v in new_cfd.items()
+            }
 
     def set_spell_slots(self, new_spell_slots: dict[str, int]) -> dict[str, int]:
         default_spell_slots = {

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -80,7 +80,6 @@ class Character:
         ability_score_bonus: int = 0,
         class_features: Optional[dict] = None,
         class_features_enabled: Optional[list] = None,
-        class_features_data: Optional[list] = None,
         spellcasting_stat: Optional[str] = None,
         player_options: Optional[dict] = None,
         armor_class: Optional[int] = None,
@@ -153,7 +152,7 @@ class Character:
         self.class_features_enabled = (
             class_features_enabled if class_features_enabled is not None else []
         )
-        self.class_features_data = self.get_class_features_data(
+        self._class_features_data = self.get_class_features_data(
             class_name=self.class_name, class_level=1 if level is None else int(level)
         )
 
@@ -414,6 +413,10 @@ class Character:
         return True
 
     @property
+    def class_features_data(self):
+        return self._class_features_data
+
+    @property
     def cantrips_known(self) -> list["_SPELL"]:
         return self._cantrips_known
 
@@ -662,12 +665,12 @@ class Character:
             class_name=self.class_name, class_level=self.level
         )
         if new_cfd is None:
-            self.class_features_data = None
+            self._class_features_data = None
         else:
-            if self.class_features_data is None:
-                self.class_features_data = new_cfd
+            if self._class_features_data is None:
+                self._class_features_data = new_cfd
             else:
-                self.class_features_data = {
+                self._class_features_data = {
                     k: v
                     if "available" not in k and "days" not in k
                     else self.class_features_data[k]

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -10,6 +10,7 @@ from .SRD import SRD, SRD_class_levels
 from .equipment import _Item, Item
 from .experience import Experience, experience_at_level, level_at_experience
 from .dice import sum_rolls
+from .features import get_class_features_data
 
 
 LOG = logging.getLogger(__package__)
@@ -146,14 +147,15 @@ class Character:
         self._class_levels = (
             [] if class_index not in SRD_class_levels else SRD_class_levels[class_index]
         )
+        self._level = 1 # may be increased later in this method
         self.prof_bonus = prof_bonus
         self.ability_score_bonus = ability_score_bonus
         self.class_features = class_features if class_features is not None else {}
         self.class_features_enabled = (
             class_features_enabled if class_features_enabled is not None else []
         )
-        self._class_features_data = self.get_class_features_data(
-            class_name=self.class_name, class_level=1 if level is None else int(level)
+        self._class_features_data = get_class_features_data(
+            character=self
         )
 
         # Hit Dice and Hit Points: self.hd == 8 is a d8, 10 is a d10, etc
@@ -186,7 +188,6 @@ class Character:
         self.set_spell_slots(spell_slots)
 
         # Experience points
-        self._level = 1
         # self.level could be altered by Experience object below
         if experience is None:
             experience = 0
@@ -661,9 +662,7 @@ class Character:
 
         # During level up some class specific values change. example: rage damage bonus 2 -> 4
         # Class specific counters do not reset! example: available inspirations
-        new_cfd = self.get_class_features_data(
-            class_name=self.class_name, class_level=self.level
-        )
+        new_cfd = get_class_features_data(character=self)
         if new_cfd is None:
             self._class_features_data = None
         else:
@@ -673,7 +672,7 @@ class Character:
                 self._class_features_data = {
                     k: v
                     if "available" not in k and "days" not in k
-                    else self.class_features_data[k]
+                    else self._class_features_data[k]
                     for k, v in new_cfd.items()
                 }
 
@@ -867,173 +866,3 @@ class Character:
             + ((int(hd / 2) + 1) * (level - 1))
             + Character.get_ability_modifier(constitution)
         )
-
-    def get_class_features_data(self, class_name, class_level):
-        """
-        Creates a dict for class features. Assumes a fully rested character!
-        """
-        if class_level is None or class_name is None:
-            return None
-
-        # Load level appropriate class features
-        data = SRD_class_levels[class_name.lower()][class_level - 1][
-            "class_specific"
-        ].copy()
-
-        # Create class feature counters
-        if class_name == "Barbarian":
-            data["max_rage_count"] = data["rage_count"]
-            data.pop("rage_count")
-
-        elif class_name == "Bard":
-            data["max_inspiration_count"] = max(
-                1, self.get_ability_modifier(self.charisma)
-            )
-
-        elif class_name == "Cleric":
-            data["max_channel_divinity_charges"] = data["channel_divinity_charges"]
-            data.pop("channel_divinity_charges")
-
-            data["max_divine_intervention_charges"] = 1 if class_level >= 10 else 0
-
-        elif class_name == "Druid":
-            data["max_wild_shape_charges"] = 1 if class_level >= 2 else 0
-
-        elif class_name == "Fighter":
-            data["max_action_surges"] = data["action_surges"]
-            data.pop("action_surges")
-
-            data["max_indomitable_uses"] = data["indomitable_uses"]
-            data.pop("indomitable_uses")
-
-            data["max_second_wind"] = 1
-            data["available_second_wind"] = 1
-
-        elif class_name == "Monk":
-            data["max_ki_points"] = data["ki_points"]
-            data.pop("ki_points")
-
-            data["max_wholeness_of_body"] = 1 if class_level >= 6 else 0
-
-        elif class_name == "Paladin":
-            data["max_divine_sense"] = 1 + self.get_ability_modifier(self.charisma)
-            data["max_lay_on_hands_points"] = 5 * class_level
-            data["max_channel_divinity"] = 1
-            data["max_cleansing_touch"] = max(
-                1, self.get_ability_modifier(self.charisma)
-            )
-
-        elif class_name == "Ranger":
-            pass  # No interaction between class features and rest mechanic
-
-        elif class_name == "Rogue":
-            data["max_stroke_of_luck"] = 1 if class_level >= 20 else 0
-
-        elif class_name == "Sorcerer":
-            data["max_sorcery_points"] = data["sorcery_points"]
-            data.pop("sorcery_points")
-
-        elif class_name == "Warlock":
-            data["max_mire_the_mind"] = 1 if class_level >= 5 else 0
-            data["max_sign_of_ill_omen"] = 1 if class_level >= 5 else 0
-            data["max_dark_one's_own_luck"] = 1 if class_level >= 6 else 0
-            data["max_bewitching_whispers"] = 1 if class_level >= 7 else 0
-            data["max_dreadful_word"] = 1 if class_level >= 7 else 0
-            data["max_sculptor_of_flesh"] = 1 if class_level >= 7 else 0
-            data["max_thief_of_five_fates"] = 1 if class_level >= 7 else 0
-            data["max_minions_of_chaos"] = 1 if class_level >= 9 else 0
-            data["max_fiendish_resilience"] = 1 if class_level >= 10 else 0
-            data["max_hurl_through_hell"] = 1 if class_level >= 14 else 0
-            data["max_chains_of_carceri"] = 1 if class_level >= 20 else 0
-            data["max_eldritch_master"] = 1 if class_level >= 20 else 0
-
-        elif class_name == "Wizard":
-            data["max_arcane_recovery"] = 1
-
-        # Assign counters (initialized for a fully rested state)
-        data = self.reset_class_features_data_counters(
-            data=data, short_rest=True, long_rest=True, reset_day_counters=True
-        )
-
-        return data
-
-    def reset_class_features_data_counters(
-        self,
-        data: dict,
-        short_rest: bool,
-        long_rest: bool,
-        reset_day_counters: bool = False,
-    ):
-        if not (short_rest and long_rest):
-            raise InvalidParameterError("At least one rest type should be True!")
-
-        if self.class_name == "Barbarian":
-            if long_rest:
-                data["available_rage_count"] = data["max_rage_count"]
-
-        elif self.class_name == "Bard":
-            if long_rest or self.level >= 5:
-                data["available_inspiration_count"] = data["max_inspiration_count"]
-
-        elif self.class_name == "Cleric":
-            if long_rest:
-                data["available_divine_intervention_charges"] = data[
-                    "max_divine_intervention_charges"
-                ]
-            data["available_channel_divinity_charges"] = data[
-                "max_channel_divinity_charges"
-            ]
-            if reset_day_counters:
-                data["days_since_last_divine_intervention"] = 999  # 7 day cooldown
-
-        elif self.class_name == "Druid":
-            data["available_wild_shape_charges"] = data["max_wild_shape_charges"]
-
-        elif self.class_name == "Fighter":
-            data["available_action_surges"] = data["max_action_surges"]
-            data["available_indomitable_uses"] = data["max_indomitable_uses"]
-            data["available_second_wind"] = 1
-
-        elif self.class_name == "Monk":
-            if long_rest:
-                data["available_wholeness_of_body"] = data["max_wholeness_of_body"]
-            data["available_ki_points"] = data["max_ki_points"]
-
-        elif self.class_name == "Paladin":
-            if long_rest:
-                data["available_divine_sense"] = data["max_divine_sense"]
-                data["available_lay_on_hands_points"] = data["max_lay_on_hands_points"]
-                data["available_cleansing_touch"] = data["max_cleansing_touch"]
-            data["available_channel_divinity"] = 1
-
-        elif self.class_name == "Ranger":
-            pass  # No interaction between class features and rest mechanic
-
-        elif self.class_name == "Rogue":
-            data["available_stroke_of_luck"] = data["max_stroke_of_luck"]
-
-        elif self.class_name == "Sorcerer":
-            if long_rest:
-                data["available_sorcery_points"] = data["max_sorcery_points"]
-
-        elif self.class_name == "Warlock":
-            if long_rest:
-                data["available_mire_the_mind"] = data["max_mire_the_mind"]
-                data["available_sign_of_ill_omen"] = data["max_sign_of_ill_omen"]
-                data["available_dark_one's_own_luck"] = data["max_dark_one's_own_luck"]
-                data["available_bewitching_whispers"] = data["max_bewitching_whispers"]
-                data["available_dreadful_word"] = data["max_dreadful_word"]
-                data["available_sculptor_of_flesh"] = data["max_sculptor_of_flesh"]
-                data["available_thief_of_five_fates"] = data["max_thief_of_five_fates"]
-                data["available_minions_of_chaos"] = data["max_minions_of_chaos"]
-                data["available_fiendish_resilience"] = data["max_fiendish_resilience"]
-                data["available_hurl_through_hell"] = data["max_hurl_through_hell"]
-                data["available_chains_of_carceri"] = data["max_chains_of_carceri"]
-                data["available_eldritch_master"] = data["max_eldritch_master"]
-
-        elif self.class_name == "Wizard":
-            data["available_arcane_recovery"] = data["max_arcane_recovery"]
-            if reset_day_counters:
-                data["days_since_last_arcane_recovery"] = 999  # 1 day cooldown
-
-        return data

--- a/dnd_character/character.py
+++ b/dnd_character/character.py
@@ -663,12 +663,15 @@ class Character:
         if new_cfd is None:
             self.class_features_data = None
         else:
-            self.class_features_data = {
-                k: v
-                if "available" not in k and "days" not in k
-                else self.class_features_data[k]
-                for k, v in new_cfd.items()
-            }
+            if self.class_features_data is None:
+                self.class_features_data = new_cfd
+            else:
+                self.class_features_data = {
+                    k: v
+                    if "available" not in k and "days" not in k
+                    else self.class_features_data[k]
+                    for k, v in new_cfd.items()
+                }
 
     def set_spell_slots(self, new_spell_slots: dict[str, int]) -> dict[str, int]:
         default_spell_slots = {

--- a/dnd_character/features.py
+++ b/dnd_character/features.py
@@ -1,0 +1,206 @@
+"""
+Functions relating to managing class features.
+
+NOTE: Do not modify `character` in this file. Treat it like a constant.
+If `character` must be changed, then the function should be a method of that class instead.
+"""
+import logging
+from typing import TYPE_CHECKING
+from dnd_character.SRD import SRD_class_levels
+
+if TYPE_CHECKING:
+    from dnd_character.character import Character
+
+LOG = logging.getLogger(__package__)
+
+
+def get_class_features_data(character: "Character") -> dict:
+    """
+    Creates a dict for class features. Assumes a fully rested character!
+    """
+    class_level = character.level
+    class_name = character.class_name
+    if class_name is None:
+        return None
+
+    # Load level appropriate class features
+    data = SRD_class_levels[class_name.lower()][class_level - 1][
+        "class_specific"
+    ].copy()
+
+    # Create class feature counters
+    if class_name == "Barbarian":
+        data["max_rage_count"] = data["rage_count"]
+        data.pop("rage_count")
+
+    elif class_name == "Bard":
+        data["max_inspiration_count"] = max(
+            1, character.get_ability_modifier(character.charisma)
+        )
+
+    elif class_name == "Cleric":
+        data["max_channel_divinity_charges"] = data["channel_divinity_charges"]
+        data.pop("channel_divinity_charges")
+
+        data["max_divine_intervention_charges"] = 1 if class_level >= 10 else 0
+
+    elif class_name == "Druid":
+        data["max_wild_shape_charges"] = 1 if class_level >= 2 else 0
+
+    elif class_name == "Fighter":
+        data["max_action_surges"] = data["action_surges"]
+        data.pop("action_surges")
+
+        data["max_indomitable_uses"] = data["indomitable_uses"]
+        data.pop("indomitable_uses")
+
+        data["max_second_wind"] = 1
+        data["available_second_wind"] = 1
+
+    elif class_name == "Monk":
+        data["max_ki_points"] = data["ki_points"]
+        data.pop("ki_points")
+
+        data["max_wholeness_of_body"] = 1 if class_level >= 6 else 0
+
+    elif class_name == "Paladin":
+        data["max_divine_sense"] = 1 + character.get_ability_modifier(
+            character.charisma
+        )
+        data["max_lay_on_hands_points"] = 5 * class_level
+        data["max_channel_divinity"] = 1
+        data["max_cleansing_touch"] = max(
+            1, character.get_ability_modifier(character.charisma)
+        )
+
+    elif class_name == "Ranger":
+        pass  # No interaction between class features and rest mechanic
+
+    elif class_name == "Rogue":
+        data["max_stroke_of_luck"] = 1 if class_level >= 20 else 0
+
+    elif class_name == "Sorcerer":
+        data["max_sorcery_points"] = data["sorcery_points"]
+        data.pop("sorcery_points")
+
+    elif class_name == "Warlock":
+        data["max_mire_the_mind"] = 1 if class_level >= 5 else 0
+        data["max_sign_of_ill_omen"] = 1 if class_level >= 5 else 0
+        data["max_dark_one's_own_luck"] = 1 if class_level >= 6 else 0
+        data["max_bewitching_whispers"] = 1 if class_level >= 7 else 0
+        data["max_dreadful_word"] = 1 if class_level >= 7 else 0
+        data["max_sculptor_of_flesh"] = 1 if class_level >= 7 else 0
+        data["max_thief_of_five_fates"] = 1 if class_level >= 7 else 0
+        data["max_minions_of_chaos"] = 1 if class_level >= 9 else 0
+        data["max_fiendish_resilience"] = 1 if class_level >= 10 else 0
+        data["max_hurl_through_hell"] = 1 if class_level >= 14 else 0
+        data["max_chains_of_carceri"] = 1 if class_level >= 20 else 0
+        data["max_eldritch_master"] = 1 if class_level >= 20 else 0
+
+    elif class_name == "Wizard":
+        data["max_arcane_recovery"] = 1
+
+    # Assign counters (initialized for a fully rested state)
+    data = reset_class_features_data_counters(
+        character=character,
+        data=data,
+        short_rest=True,
+        long_rest=True,
+        reset_day_counters=True,
+    )
+
+    return data
+
+
+def reset_class_features_data_counters(
+    character: "Character",
+    data: dict,
+    short_rest: bool,
+    long_rest: bool,
+    reset_day_counters: bool = False,
+) -> dict:
+    """
+    Reset counters for class features that deplete and/or cooldown
+    A counter that depletes: barbarian's available_rage_count
+    A counter that depletes and has cooldown: cleric's divine intervention
+    """
+    if not short_rest and not long_rest:
+        LOG.warning(
+            "Calling `reset_class_features_data_counters` with short_rest and long_short both set to False. This is meaningless."
+        )
+        return data
+
+    class_name = character.class_name
+
+    if class_name == "Barbarian":
+        if long_rest:
+            data["available_rage_count"] = data["max_rage_count"]
+
+    elif class_name == "Bard":
+        if long_rest or character.level >= 5:
+            data["available_inspiration_count"] = data["max_inspiration_count"]
+
+    elif class_name == "Cleric":
+        if long_rest:
+            data["available_divine_intervention_charges"] = data[
+                "max_divine_intervention_charges"
+            ]
+        data["available_channel_divinity_charges"] = data[
+            "max_channel_divinity_charges"
+        ]
+        if reset_day_counters:
+            # TODO implement 7 day cooldown
+            data["days_since_last_divine_intervention"] = 999
+
+    elif class_name == "Druid":
+        data["available_wild_shape_charges"] = data["max_wild_shape_charges"]
+
+    elif class_name == "Fighter":
+        data["available_action_surges"] = data["max_action_surges"]
+        data["available_indomitable_uses"] = data["max_indomitable_uses"]
+        data["available_second_wind"] = 1
+
+    elif class_name == "Monk":
+        if long_rest:
+            data["available_wholeness_of_body"] = data["max_wholeness_of_body"]
+        data["available_ki_points"] = data["max_ki_points"]
+
+    elif class_name == "Paladin":
+        if long_rest:
+            data["available_divine_sense"] = data["max_divine_sense"]
+            data["available_lay_on_hands_points"] = data["max_lay_on_hands_points"]
+            data["available_cleansing_touch"] = data["max_cleansing_touch"]
+        data["available_channel_divinity"] = 1
+
+    elif class_name == "Ranger":
+        pass  # No interaction between class features and rest mechanic
+
+    elif class_name == "Rogue":
+        data["available_stroke_of_luck"] = data["max_stroke_of_luck"]
+
+    elif class_name == "Sorcerer":
+        if long_rest:
+            data["available_sorcery_points"] = data["max_sorcery_points"]
+
+    elif class_name == "Warlock":
+        if long_rest:
+            data["available_mire_the_mind"] = data["max_mire_the_mind"]
+            data["available_sign_of_ill_omen"] = data["max_sign_of_ill_omen"]
+            data["available_dark_one's_own_luck"] = data["max_dark_one's_own_luck"]
+            data["available_bewitching_whispers"] = data["max_bewitching_whispers"]
+            data["available_dreadful_word"] = data["max_dreadful_word"]
+            data["available_sculptor_of_flesh"] = data["max_sculptor_of_flesh"]
+            data["available_thief_of_five_fates"] = data["max_thief_of_five_fates"]
+            data["available_minions_of_chaos"] = data["max_minions_of_chaos"]
+            data["available_fiendish_resilience"] = data["max_fiendish_resilience"]
+            data["available_hurl_through_hell"] = data["max_hurl_through_hell"]
+            data["available_chains_of_carceri"] = data["max_chains_of_carceri"]
+            data["available_eldritch_master"] = data["max_eldritch_master"]
+
+    elif class_name == "Wizard":
+        data["available_arcane_recovery"] = data["max_arcane_recovery"]
+        if reset_day_counters:
+            # TODO implement 1 day cooldown
+            data["days_since_last_arcane_recovery"] = 999
+
+    return data

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -5,6 +5,7 @@ from dnd_character.features import (
     get_class_features_data,
     reset_class_features_data_counters,
 )
+from dnd_character.experience import experience_at_level
 
 
 @pytest.mark.parametrize(
@@ -57,24 +58,55 @@ def test_class_features_data_exist_after_init(input, expected_value):
     assert c.class_features_data == expected_value
 
 
-def test_reset_class_features_data_bard_level_4():
-    c = Character(classs=CLASSES["bard"], level=4, charisma=10)
-    # inspiration count should be 4 in this situation
+def test_reset_class_features_data_bard_level_1():
+    c = Character(classs=CLASSES["bard"], level=1, charisma=10)
+    # inspiration count should be 1 in this situation
     data = get_class_features_data(c)
-    data["available_inspiration_count"] = 1
-    # at level 4 a short rest should NOT restore inspiration count
+    assert data["max_inspiration_count"] == 1
+    data["available_inspiration_count"] = 0
+    # at level 1 a short rest should NOT restore inspiration count
     data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
-    assert data["available_inspiration_count"] == 1
+    assert data["available_inspiration_count"] == 0
     # a long rest should always restore inspiration count
     data = reset_class_features_data_counters(character=c, data=data, short_rest=False, long_rest=True)
-    assert data["available_inspiration_count"] == 4
+    assert data["available_inspiration_count"] == 1
 
 
 def test_reset_class_features_data_bard_level_5():
     c = Character(classs=CLASSES["bard"], level=5, charisma=10)
     # inspiration count should be 5 in this situation
     data = get_class_features_data(c)
-    data["available_inspiration_count"] = 1
+    assert data["max_inspiration_count"] == 1
+    data["available_inspiration_count"] = 0
     # at level 5 a short rest should restore inspiration count
     data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
-    assert data["available_inspiration_count"] == 5
+    assert data["available_inspiration_count"] == 1
+
+
+def test_class_features_data_monk_ki_points_level_1():
+    c = Character(classs=CLASSES["monk"])
+    assert c.class_features_data["max_ki_points"] == 0
+
+
+def test_class_features_data_monk_ki_points_level_2_init():
+    c = Character(classs=CLASSES["monk"], level=2)
+    assert c.class_features_data["max_ki_points"] == 2
+
+
+def test_class_features_data_monk_ki_points_level_2_init_experience():
+    c = Character(classs=CLASSES["monk"], experience=experience_at_level(2))
+    assert c.class_features_data["max_ki_points"] == 2
+
+
+def test_class_features_data_monk_ki_points_level_increase_level():
+    c = Character(classs=CLASSES["monk"])
+    assert c.class_features_data["max_ki_points"] == 0
+    c.level = 2
+    assert c.class_features_data["max_ki_points"] == 2
+
+
+def test_class_features_data_monk_ki_points_level_increase_experience():
+    c = Character(classs=CLASSES["monk"])
+    assert c.class_features_data["max_ki_points"] == 0
+    c.experience = experience_at_level(2)
+    assert c.class_features_data["max_ki_points"] == 2

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -1,5 +1,6 @@
 import pytest
 from dnd_character import Character
+from dnd_character.classes import CLASSES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -114,5 +114,8 @@ def test_class_features_data_monk_ki_points_level_increase_level():
 def test_class_features_data_monk_ki_points_level_increase_experience():
     c = Character(classs=CLASSES["monk"])
     assert c.class_features_data["max_ki_points"] == 0
+    assert c.class_features_data["available_ki_points"] == 0
     c.experience = experience_at_level(2)
     assert c.class_features_data["max_ki_points"] == 2
+    # available counter stays at 0 after level up despite max increasing
+    assert c.class_features_data["available_ki_points"] == 0

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -6,8 +6,16 @@ from dnd_character.classes import CLASSES
 @pytest.mark.parametrize(
     ("input", "expected_value"),
     (
-        ({"classs": CLASSES["barbarian"]}, None),
         ({"level": 1}, None),
+        (
+            {"classs": CLASSES["barbarian"]},
+            {
+                "brutal_critical_dice": 0,
+                "max_rage_count": 2,
+                "available_rage_count": 2,
+                "rage_damage_bonus": 2,
+            },
+        ),
         (
             {"classs": CLASSES["barbarian"], "level": 9},
             {
@@ -32,8 +40,9 @@ from dnd_character.classes import CLASSES
         (
             {"classs": CLASSES["wizard"], "level": 20},
             {
-                "max_arcane_recovery": 10,
-                "available_arcane_recovery": 10,
+                "arcane_recovery_levels": 10,
+                "max_arcane_recovery": 1,
+                "available_arcane_recovery": 1,
                 "days_since_last_arcane_recovery": 999,
             },
         ),

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -1,0 +1,43 @@
+import pytest
+from dnd_character import Character
+
+
+@pytest.mark.parametrize(
+    ("input", "expected_value"),
+    (
+        ({"classs": CLASSES["barbarian"]}, None),
+        ({"level": 1}, None),
+        (
+            {"classs": CLASSES["barbarian"], "level": 9},
+            {
+                "brutal_critical_dice": 1,
+                "max_rage_count": 4,
+                "available_rage_count": 4,
+                "rage_damage_bonus": 3,
+            },
+        ),
+        (
+            {"classs": CLASSES["bard"], "level": 1, "charisma": 14},
+            {
+                "bardic_inspiration_die": 6,
+                "magical_secrets_max_5": 0,
+                "magical_secrets_max_7": 0,
+                "magical_secrets_max_9": 0,
+                "song_of_rest_die": 0,
+                "max_inspiration_count": 2,
+                "available_inspiration_count": 2,
+            },
+        ),
+        (
+            {"classs": CLASSES["wizard"], "level": 20},
+            {
+                "max_arcane_recovery": 10,
+                "available_arcane_recovery": 10,
+                "days_since_last_arcane_recovery": 999,
+            },
+        ),
+    ),
+)
+def test_class_features_data_exist(input, expected_value):
+    c = Character(**input)
+    assert c.class_features_data == expected_value

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -1,6 +1,10 @@
 import pytest
 from dnd_character import Character
 from dnd_character.classes import CLASSES
+from dnd_character.features import (
+    get_class_features_data,
+    reset_class_features_data_counters,
+)
 
 
 @pytest.mark.parametrize(
@@ -48,6 +52,29 @@ from dnd_character.classes import CLASSES
         ),
     ),
 )
-def test_class_features_data_exist(input, expected_value):
+def test_class_features_data_exist_after_init(input, expected_value):
     c = Character(**input)
     assert c.class_features_data == expected_value
+
+
+def test_reset_class_features_data_bard_level_4():
+    c = Character(classs=CLASSES["bard"], level=4, charisma=10)
+    # inspiration count should be 4 in this situation
+    data = get_class_features_data(c)
+    data["available_inspiration_count"] = 1
+    # at level 4 a short rest should NOT restore inspiration count
+    data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
+    assert data["available_inspiration_count"] == 1
+    # a long rest should always restore inspiration count
+    data = reset_class_features_data_counters(character=c, data=data, short_rest=False, long_rest=True)
+    assert data["available_inspiration_count"] == 4
+
+
+def test_reset_class_features_data_bard_level_5():
+    c = Character(classs=CLASSES["bard"], level=5, charisma=10)
+    # inspiration count should be 5 in this situation
+    data = get_class_features_data(c)
+    data["available_inspiration_count"] = 1
+    # at level 5 a short rest should restore inspiration count
+    data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
+    assert data["available_inspiration_count"] == 5

--- a/tests/test_class_features_data.py
+++ b/tests/test_class_features_data.py
@@ -65,10 +65,14 @@ def test_reset_class_features_data_bard_level_1():
     assert data["max_inspiration_count"] == 1
     data["available_inspiration_count"] = 0
     # at level 1 a short rest should NOT restore inspiration count
-    data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
+    data = reset_class_features_data_counters(
+        character=c, data=data, short_rest=True, long_rest=False
+    )
     assert data["available_inspiration_count"] == 0
     # a long rest should always restore inspiration count
-    data = reset_class_features_data_counters(character=c, data=data, short_rest=False, long_rest=True)
+    data = reset_class_features_data_counters(
+        character=c, data=data, short_rest=False, long_rest=True
+    )
     assert data["available_inspiration_count"] == 1
 
 
@@ -79,7 +83,9 @@ def test_reset_class_features_data_bard_level_5():
     assert data["max_inspiration_count"] == 1
     data["available_inspiration_count"] = 0
     # at level 5 a short rest should restore inspiration count
-    data = reset_class_features_data_counters(character=c, data=data, short_rest=True, long_rest=False)
+    data = reset_class_features_data_counters(
+        character=c, data=data, short_rest=True, long_rest=False
+    )
     assert data["available_inspiration_count"] == 1
 
 


### PR DESCRIPTION
Discussed in #19 

Not discussed in #19:
- `get_class_features_data` function has two parameter `class_name` and `level`. If multi class characters will be possible then this function will only need a wrapper which gets class levels and concats the results.
- During leveling a simple call for `get_class_features_data` is not enough. Counter types shouldn't be reseted!

There is a huge amount of counter type mechanics. I double checked everything but it is possible I have missed something. 
I created a simple test but it doesn't cover every edge case.

Closes #19 